### PR TITLE
fix(docs): add operator to docker group in task-4

### DIFF
--- a/lab/tasks/required/task-4.md
+++ b/lab/tasks/required/task-4.md
@@ -208,7 +208,13 @@ Use any of the following methods:
    usermod -aG sudo operator
    ```
 
-5. [Copy SSH authorized keys to the `operator` user](../../../wiki/vm-autochecker.md#copy-ssh-authorized-keys-to-a-user).
+5. Add the user to the `docker` group:
+
+   ```terminal
+   usermod -aG docker operator
+   ```
+
+6. [Copy SSH authorized keys to the `operator` user](../../../wiki/vm-autochecker.md#copy-ssh-authorized-keys-to-a-user).
 
    Replace `<username>` with `operator`.
 


### PR DESCRIPTION
## Summary
- Add `usermod -aG docker operator` to step 11 (Create a non-root SSH user), right after granting `sudo`.
- Without this, students get `permission denied` on the Docker socket when they SSH as `operator` in lab-4, since root login is disabled.